### PR TITLE
Fix import mapping for code generation

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -457,7 +457,7 @@ public class DefaultGenerator implements Generator {
         for (String name : modelKeys) {
             try {
                 //don't generate models that have an import mapping
-                if (config.schemaMapping().containsKey(name)) {
+                if (config.importMapping().containsKey(name)) {
                     LOGGER.debug("Model {} not imported due to import mapping", name);
 
                     for (String templateName : config.modelTemplateFiles().keySet()) {


### PR DESCRIPTION
Changed DefaultGenerator to check importMapping to check importMapping instead of schemaMapping, as the above comment suggested