### PR TITLE
Add compass.yml (adopt Compass component as config-as-code)

### DIFF
--- a/compass.yml
+++ b/compass.yml
@@ -1,0 +1,10 @@
+# Adopts this repo's existing Compass component as config-as-code.
+# Managed by EngOps from truths/components.json + repositories.json.
+name: Openapi Generator
+id: ari:cloud:compass:4337fc0d-aa55-4ff9-bd75-ef7117ff9381:component/4c6fdffe-fa4a-46ef-9e6f-a1aa05480c89/ca05eb5e-086e-4577-b58e-712b7e599ca4
+configVersion: 1
+typeId: SERVICE
+ownerId: ari:cloud:identity::team/b23f7e67-bf69-456b-866a-cad94ddf7f2c # Authentics - IAM (301)
+links:
+  - type: REPOSITORY
+    url: https://github.com/EENCloud/openapi-generator


### PR DESCRIPTION
## Adopt this repo's Compass component via config-as-code

This repo's Compass component (**Openapi Generator**) is currently manually managed. This `compass.yml` adopts it — `id:` is the existing component ARI (manages the same component, no duplicate), owner **Authentics - IAM (301)**.

On merge, the GitHub-for-Compass sync binds it as config-as-code; no state change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)