### PR TITLE
Add: Claude automated PR review

### DIFF
--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -1,0 +1,40 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, review_requested]
+
+# Cancel any in-flight review when a new commit lands on the same PR
+# so we always review the latest revision (and don't burn API credits
+# on superseded reviews). Same pattern as engops/claude-code-review.yml.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  claude-review:
+    # Dependabot PRs can't access org secrets, so the Vault step would
+    # fail at credential-import. Skip them at the workflow level.
+    if: github.actor != 'dependabot[bot]'
+    # Explicit minimum permissions — the reusable workflow needs to post
+    # the review comment and (where applicable) react to PR events. Set
+    # at the caller layer so the workflow works regardless of the target
+    # repo's default GITHUB_TOKEN policy.
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    # Intentionally pinned to @main: every enrolled repo picks up
+    # workflow-library updates centrally. Trade-off accepted — a
+    # breaking change in workflow-library hits all enrolled repos at
+    # once, but the alternative (pin to a tag here, then re-enroll
+    # every repo on each library bump) doesn't scale at the org size.
+    # If a staged rollout is ever needed, change this line to a tag /
+    # SHA and rerun claude-review-enrollment.yml so the new template
+    # propagates as fresh PRs.
+    uses: EENCloud/workflow-library/.github/workflows/claude_auto_review.yml@main
+    secrets:
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
+      VAULT_CA_CERT: ${{ secrets.VAULT_CA_CERT }}


### PR DESCRIPTION
Enrolls this repo in automated Claude PR reviews via the `claude_auto_review` reusable workflow in `workflow-library`.

Every PR will be reviewed by RobotEagle (Claude) automatically on open, when marked ready for review, or when a review is requested from RobotEagle. To request a re-review after new commits, tag `@claude` in a PR comment or re-request a review from RobotEagle.

## Before merging — Vault setup required

The workflow fetches the team's Anthropic API key from Vault. The key name is derived from the `ownerId` in `compass.yml`:

```bash

# Run this against the repo's compass.yml to find the Vault key name:

OWNER_ID=$(grep -m1 '^ownerId:' compass.yml | sed 's/^ownerId: *//' | tr -d '"' | xargs)

UUID=$(echo "$OWNER_ID" | sed 's/.*\///')

echo "team_$(echo "$UUID" | tr '-' '_')"
```

Ask a Vault admin to add the Anthropic API key at `secret/github/actions/claude` under that key name. If your team's key is already registered (another repo in the same team is already enrolled), no action is needed.

## Remove any existing Claude review workflows

If this repo already has a workflow that triggers Claude PR reviews (e.g. a `claude.yml` calling `claude_auto_review.yml`), **delete it when merging this PR**. Keeping both will cause every PR to receive two reviews.
