### PR TITLE
fix(compass): add/correct slug fields

### DIFF
--- a/compass.yml
+++ b/compass.yml
@@ -2,6 +2,7 @@
 # Managed by EngOps from truths/components.json + repositories.json.
 name: Openapi Generator
 id: ari:cloud:compass:4337fc0d-aa55-4ff9-bd75-ef7117ff9381:component/4c6fdffe-fa4a-46ef-9e6f-a1aa05480c89/ca05eb5e-086e-4577-b58e-712b7e599ca4
+slug: openapi-generator
 configVersion: 1
 typeId: SERVICE
 ownerId: ari:cloud:identity::team/b23f7e67-bf69-456b-866a-cad94ddf7f2c # Authentics - IAM (301)


### PR DESCRIPTION
## Summary

Adds or corrects `slug:` fields in compass.yml file(s). The slug is derived from the component `name:` field, kebab-cased — the canonical form Compass uses internally. Using the name (rather than the repo name) handles monorepos naturally: each component in a repo has its own distinct name and therefore its own unique slug.

- `compass.yml`: add `slug: openapi-generator`

🤖 Generated by `scripts/fix-compass-slugs.js`